### PR TITLE
WIN32 crash fix & initial dialog sizing fix

### DIFF
--- a/src/calculatorgui_impl.cpp
+++ b/src/calculatorgui_impl.cpp
@@ -36,6 +36,7 @@ Dlg::Dlg( wxWindow* parent, wxWindowID id, const wxString& title, const wxPoint&
     prs.parse("dtr=0.0174532925"); //define degree to radians conversion factor
     this->HelpPanel->Show(false);
     this->m_Overview->Layout();
+    this->Layout();
     this->Fit();
 }
 

--- a/src/expression_parser/error.cpp
+++ b/src/expression_parser/error.cpp
@@ -43,7 +43,11 @@ Error::Error(const int row, const int col, const int id, ...)
     const char* msg_desc = msgdesc(id);
 
     va_list args;
+#if(__WIN32__)
+    va_start(args, id);
+#else
     va_start(args, msg_desc);
+#endif
     vsnprintf(msg, sizeof(msg)-1, msg_desc, args);
     msg[sizeof(msg)-1] = '\0';
     va_end(args);


### PR DESCRIPTION
Hi Salty...
I've finally found some time to really try to run the plugin on Windows - the crashes came from the exception handling code. This should fix them.

Pavel
